### PR TITLE
products_model_create

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,0 +1,2 @@
+class Product < ApplicationRecord
+end

--- a/db/migrate/20200303120845_create_products.rb
+++ b/db/migrate/20200303120845_create_products.rb
@@ -1,0 +1,18 @@
+class CreateProducts < ActiveRecord::Migration[5.0]
+  def change
+    create_table :products do |t|
+      # t.references :user, foreign_key: true
+      # t.references :image, foreign_key: true
+      t.string :name, null: false
+      t.text :description, null: false
+      # t.references :category, foreign_key: true
+      # t.references :brand, foreign_key: true
+      t.string :condition, null: false
+      t.string :shipping_charges, null: false
+      t.string :shipping_area, null: false
+      t.string :days_to_delivery, null: false
+      t.integer :price, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200302121105) do
+ActiveRecord::Schema.define(version: 20200303120845) do
+
+  create_table "products", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "name",                           null: false
+    t.text     "description",      limit: 65535, null: false
+    t.string   "condition",                      null: false
+    t.string   "shipping_charges",               null: false
+    t.string   "shipping_area",                  null: false
+    t.string   "days_to_delivery",               null: false
+    t.integer  "price",                          null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+  end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "email",                  default: "", null: false

--- a/test/fixtures/products.yml
+++ b/test/fixtures/products.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ProductTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# What
商品用のテーブルをDB設計を参考に作成。
現状、外部キーの項目はマイグレーションファイル上でコメントアウトし、無効化。
# Why
商品出品時に商品情報を登録できるようにするため。