### PR TITLE
エラーメッセージの日本語化のfix

### DIFF
--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
           has_many: "%{record}が存在しているので削除できません"
     models:
       address: 住所
+      product: 商品
     attributes:
       address:
         last_name: 苗字
@@ -21,9 +22,6 @@ ja:
         house_number: 番地
         building: 建物名
         phone_number: 電話番号
-    models:
-      product: 商品
-    attributes:
       product:
         name: 商品名
         description: 商品の説明


### PR DESCRIPTION
# What
エラーメッセージの日本語化のエラーが出てしまったので修正
・ja.ymlの記述の修正
# Why
エラーメッセージを正しく表示させるため