### PR TITLE
fix：新規登録時の電話番号のバリデーション修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
 
   validates :email, format: { with: EMAIL_REGEXP }, uniqueness: true
   validates :password, format: { with: PASSWORD_REGEXP }, length: { minimum: 7 }
-  validates :phone_number, uniqueness: true, allow_nil: true, format: { with: PHONE_REGEXP }
+  validates :phone_number, uniqueness: true, allow_blank: true, format: { with: PHONE_REGEXP }
 
   # Associations
   # has_many :credit_cards


### PR DESCRIPTION
## What
修正依頼のあった新規登録時のバリデーションを修正

## Why
任意の登録箇所なのに未入力でエラーが出てしまう