### PR TITLE
カテゴリーサイズに不正な値

### DIFF
--- a/app/assets/javascripts/category_form.js
+++ b/app/assets/javascripts/category_form.js
@@ -44,7 +44,7 @@ $(function() {
                           <div class='size-title__required'>任意</div>
                         </div>
                         <select class="size-box" id="size" name="product[products_size_id]">
-                          <option value="---">---</option>
+                          <option value="">---</option>
                           ${insertHTML}
                         </select>
                       </div>`;


### PR DESCRIPTION
# What
商品の出品時にカテゴリーで服を選択、サイズのプルダウンを表示させ、初期値のまま出品するとエラーが出てしまう。
# Why
商品サイズのプルダウンの初期値設定に---が入っていた為、外部キーである商品サイズでエラーが発生していた。